### PR TITLE
feat: max team name & tag length config

### DIFF
--- a/src/main/java/com/bba/allied/commands/adminCommands.java
+++ b/src/main/java/com/bba/allied/commands/adminCommands.java
@@ -67,7 +67,56 @@ public class adminCommands {
                                         })
                                 )
                         )
+                        .then(Commands.literal("maxTeamNameLength")
+                                .then(Commands.argument("value", IntegerArgumentType.integer(1))
+                                        .executes(context -> {
+                                            ServerPlayer player = context.getSource().getPlayer();
+                                            if (player == null) return 0;
 
+                                            int newLength = IntegerArgumentType.getInteger(context, "value");
+                                            CompoundTag data = datManager.get().getData();
+                                            CompoundTag settings = data.getCompoundOrEmpty("settings");
+                                            settings.putInt("maxTeamNameLength", newLength);
+
+                                            try {
+                                                datManager.get().save();
+                                            } catch (IOException e) {
+                                                throw new RuntimeException(e);
+                                            }
+
+                                            context.getSource().sendSuccess(
+                                                    () -> Component.literal("Team name max length set to " + newLength),
+                                                    false
+                                            );
+                                            return 1;
+                                        })
+                                )
+                        )
+                        .then(Commands.literal("maxTeamTagLength")
+                                .then(Commands.argument("value", IntegerArgumentType.integer(1))
+                                        .executes(context -> {
+                                            ServerPlayer player = context.getSource().getPlayer();
+                                            if (player == null) return 0;
+
+                                            int newLength = IntegerArgumentType.getInteger(context, "value");
+                                            CompoundTag data = datManager.get().getData();
+                                            CompoundTag settings = data.getCompoundOrEmpty("settings");
+                                            settings.putInt("maxTeamTagLength", newLength);
+
+                                            try {
+                                                datManager.get().save();
+                                            } catch (IOException e) {
+                                                throw new RuntimeException(e);
+                                            }
+
+                                            context.getSource().sendSuccess(
+                                                    () -> Component.literal("Team tag max length set to " + newLength),
+                                                    false
+                                            );
+                                            return 1;
+                                        })
+                                )
+                        )
                         .then(Commands.literal("info")
                                 .then(Commands.argument("teamName", StringArgumentType.string())
                                         .suggests((context, builder) -> {

--- a/src/main/java/com/bba/allied/commands/commands.java
+++ b/src/main/java/com/bba/allied/commands/commands.java
@@ -257,7 +257,11 @@ public class commands {
                                                         target.getUUID(),
                                                         context.getSource().getServer()
                                                 );
+                                            } catch (CommandSyntaxException e) {
+                                                context.getSource().sendFailure((Component) e.getRawMessage());
+                                                return 0;
                                             } catch (Exception e) {
+                                                context.getSource().sendFailure(Component.literal("Internal error occured, please contact server owner."));
                                                 e.printStackTrace();
                                                 return 0;
                                             }

--- a/src/main/java/com/bba/allied/data/datConfig.java
+++ b/src/main/java/com/bba/allied/data/datConfig.java
@@ -45,6 +45,8 @@ public class datConfig {
         settings.putBoolean("echest", true);
         ListTag blockTeamsSettings = new ListTag();
         settings.put("blockTeamsSettings", blockTeamsSettings);
+        settings.putInt("maxTeamNameLength", 16);
+        settings.putInt("maxTeamTagLength", 4);
 
         return root;
     }

--- a/src/main/java/com/bba/allied/data/datManager.java
+++ b/src/main/java/com/bba/allied/data/datManager.java
@@ -131,7 +131,9 @@ public class datManager {
             ).create();
         }
 
-        if (teamName.length() > 16 || teamTag.length() > 4) {
+        int maxNameLength = data.getIntOr("maxTeamNameLength", 16);
+        int maxTagLength = data.getIntOr("maxTeamTagLength", 4);
+        if (teamName.length() > maxNameLength || teamTag.length() > maxTagLength) {
             throw new SimpleCommandExceptionType(
                     Component.nullToEmpty("Team Name or Team Tag is too long!")
             ).create();

--- a/src/main/java/com/bba/allied/data/datManager.java
+++ b/src/main/java/com/bba/allied/data/datManager.java
@@ -710,11 +710,25 @@ public class datManager {
         switch (field) {
 
             case "name" -> {
+                int maxNameLength = data.getIntOr("maxTeamNameLength", 16);
+                if (value.length() > maxNameLength) {
+                    throw new SimpleCommandExceptionType(
+                            Component.nullToEmpty("Team Name is too long!")
+                    ).create();
+                }
                 teams.put(value, foundTeam);
                 teams.remove(foundTeamName);
             }
 
-            case "tag" -> foundTeam.putString("teamTag", value);
+            case "tag" -> {
+                int maxTagLength = data.getIntOr("maxTeamTagLength", 4);
+                if (value.length() > maxTagLength) {
+                    throw new SimpleCommandExceptionType(
+                            Component.nullToEmpty("Team Tag is too long!")
+                    ).create();
+                }
+                foundTeam.putString("teamTag", value);
+            }
 
             case "color" -> {
                 try {


### PR DESCRIPTION
Add a option to configure the maximum length of team names and tags.

I would also propose to you to switch to a different config system, because you constantly have to check if you spelt the name correctly and have to make a large command to just change one integer.
This could be fixed by having an actual config class with a parser from a file and also auto command generation. If you give me the go-ahead I will try and implement it.