### PR TITLE
Make teamChatManager public for optional integrations

### DIFF
--- a/src/main/java/com/bba/allied/teamUtils/teamChatManager.java
+++ b/src/main/java/com/bba/allied/teamUtils/teamChatManager.java
@@ -3,7 +3,8 @@ package com.bba.allied.teamUtils;
 import java.util.HashSet;
 import java.util.UUID;
 
-public class teamChatManager {
+public final class teamChatManager {
+
     private static final HashSet<UUID> TEAM_CHAT = new HashSet<>();
 
     public static void enable(UUID uuid) {
@@ -28,5 +29,3 @@ public class teamChatManager {
         }
     }
 }
-
-


### PR DESCRIPTION
Modloader: Fabric
Minecraft version: 26.1.2

## Summary

Changes `teamChatManager` from package-private to `public`.

This allows external mods to optionally query whether a player has Allied team chat enabled without modifying Allied's behavior.

A companion [SDLink PR](https://github.com/hypherionmc/sdlink/pull/229) uses this to prevent Allied team chat messages from being relayed to Discord while keeping Allied as an optional dependency.

## Changes

* Make `teamChatManager` public.
* No functional or behavioral changes.
* No changes to the team chat implementation or state management.

## Compatibility

This change is backwards compatible. It only changes the visibility of the class so other mods can access its existing public API.
