### PR TITLE
Team deleting bug fix and deleting double space

### DIFF
--- a/src/main/java/com/bba/allied/commands/commands.java
+++ b/src/main/java/com/bba/allied/commands/commands.java
@@ -623,7 +623,7 @@ public class commands {
                                                     teamUtils.rebuildTeams(server);
 
                                                     context.getSource().sendSuccess(
-                                                            () -> Component.literal("Successfully updated  " + field),
+                                                            () -> Component.literal("Successfully updated " + field),
                                                             false
                                                     );
                                                     return 1;

--- a/src/main/java/com/bba/allied/data/datManager.java
+++ b/src/main/java/com/bba/allied/data/datManager.java
@@ -718,6 +718,11 @@ public class datManager {
                             Component.nullToEmpty("Team Name is too long!")
                     ).create();
                 }
+                if (foundTeamName.equalsIgnoreCase(value)) {
+						throw new SimpleCommandExceptionType(
+								Text.literal("You are already using this Team Name.")
+								).create();
+                }
                 teams.put(value, foundTeam);
                 teams.remove(foundTeamName);
             }

--- a/src/main/java/com/bba/allied/data/datManager.java
+++ b/src/main/java/com/bba/allied/data/datManager.java
@@ -721,7 +721,7 @@ public class datManager {
                 if (foundTeamName.equalsIgnoreCase(value)) {
 						throw new SimpleCommandExceptionType(
 								Text.literal("You are already using this Team Name.")
-								).create();
+							).create();
                 }
                 teams.put(value, foundTeam);
                 teams.remove(foundTeamName);


### PR DESCRIPTION
Fixes bug when changing team name with "/allied set name XXX" would delete your team if your team name is XXX